### PR TITLE
Gas Price: Use the gas price of the currently configured chain

### DIFF
--- a/app/base/composables/gasPrice.ts
+++ b/app/base/composables/gasPrice.ts
@@ -7,10 +7,11 @@ let priceWatcher: WatchStopHandle|null = null
 const price: Ref<bigint> = ref(0n)
 export const useGasPrice = () => {
   const config = useConfig()
-  const { data: blockNumber } = useBlockNumber()
+  const runtimeConfig = useRuntimeConfig()
+  const { data: blockNumber } = useBlockNumber({ chainId: runtimeConfig.public.chainId })
 
   const updatePrice = async () => {
-    price.value = await getGasPrice(config)
+    price.value = await getGasPrice(config, { chainId: runtimeConfig.public.chainId })
   }
 
   if (! priceWatcher) {


### PR DESCRIPTION
Tiny change to display the price using the gas of the current chain, instead of Ethereum Mainnet.